### PR TITLE
Export account's num_sponsored and num_sponsoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For each account the following metrics are exported:
  * *stellar_account_balance*
  * *stellar_account_buying_liabilities*
  * *stellar_account_selling_liabilities*
+ * *stellar_account_num_sponsored*
 
 Each metric has the following labels:
  * *network* - network name from the configuration file

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ For each account the following metrics are exported:
  * *stellar_account_buying_liabilities*
  * *stellar_account_selling_liabilities*
  * *stellar_account_num_sponsored*
+ * *stellar_account_num_sponsoring*
 
 Each metric has the following labels:
  * *network* - network name from the configuration file

--- a/stellar_account_prometheus_exporter/exporter.py
+++ b/stellar_account_prometheus_exporter/exporter.py
@@ -64,6 +64,8 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
                                       label_names, registry=self.registry)
         m_num_sponsored = Gauge("stellar_account_num_sponsored", "Stellar core account number of sponsored entries",
                                       label_names, registry=self.registry)
+        m_num_sponsoring = Gauge("stellar_account_num_sponsoring", "Stellar core account number of sponsoring entries",
+                                      label_names, registry=self.registry)
 
         for network in config["networks"]:
             if "accounts" not in network or "name" not in network or "horizon_url" not in network:
@@ -88,12 +90,16 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
                 if "num_sponsored" not in r.json():
                     self.error(500, "Error - no num_sponsored found for account {}".format(account["account_id"]))
                     return
+                if "num_sponsoring" not in r.json():
+                    self.error(500, "Error - no num_sponsoring found for account {}".format(account["account_id"]))
+                    return
                 for balance in r.json()["balances"]:
                     labels = [network["name"], account["account_id"], account["account_name"], balance["asset_type"]]
                     m_balance.labels(*labels).set(balance["balance"])
                     m_buying_liabilities.labels(*labels).set(balance["buying_liabilities"])
                     m_selling_liabilities.labels(*labels).set(balance["selling_liabilities"])
                     m_num_sponsored.labels(*labels).set(r.json()["num_sponsored"])
+                    m_num_sponsoring.labels(*labels).set(r.json()["num_sponsoring"])
 
         output = generate_latest(self.registry)
         self.send_response(200)

--- a/stellar_account_prometheus_exporter/exporter.py
+++ b/stellar_account_prometheus_exporter/exporter.py
@@ -62,6 +62,8 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
                                      label_names, registry=self.registry)
         m_selling_liabilities = Gauge("stellar_account_selling_liabilities", "Stellar core account selling liabilities",
                                       label_names, registry=self.registry)
+        m_num_sponsored = Gauge("stellar_account_num_sponsored", "Stellar core account number of sponsored entries",
+                                      label_names, registry=self.registry)
 
         for network in config["networks"]:
             if "accounts" not in network or "name" not in network or "horizon_url" not in network:
@@ -83,11 +85,15 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
                 if "balances" not in r.json():
                     self.error(500, "Error - no balances found for account {}".format(account["account_id"]))
                     return
+                if "num_sponsored" not in r.json():
+                    self.error(500, "Error - no num_sponsored found for account {}".format(account["account_id"]))
+                    return
                 for balance in r.json()["balances"]:
                     labels = [network["name"], account["account_id"], account["account_name"], balance["asset_type"]]
                     m_balance.labels(*labels).set(balance["balance"])
                     m_buying_liabilities.labels(*labels).set(balance["buying_liabilities"])
                     m_selling_liabilities.labels(*labels).set(balance["selling_liabilities"])
+                    m_num_sponsored.labels(*labels).set(r.json()["num_sponsored"])
 
         output = generate_latest(self.registry)
         self.send_response(200)


### PR DESCRIPTION
### What
Export account's num_sponsored and num_sponsoring through the gauges:
* stellar_account_num_sponsored
* stellar_account_num_sponsoring

### Why
Since protocol 15 was released, we need to look not only at the account's balance but also the `num_sponsored` and `num_sponsoring` to calculate the total available balance a stellar account has.

### Further discussion
Additionally we could export a variable `stellar_account_available_balance` that already accounts for the number of sponsored and sponsoring entries.