### PR TITLE
Implement `stellar_account_available_balance`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For each account the following metrics are exported:
  * *stellar_account_selling_liabilities*
  * *stellar_account_num_sponsored*
  * *stellar_account_num_sponsoring*
+ * *stellar_account_minimum_balance*
 
 Each metric has the following labels:
  * *network* - network name from the configuration file

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ By default the exporter listens on port 9618. This can be changes using
 
 For each account the following metrics are exported:
  * *stellar_account_balance*
+ * *stellar_account_available_balance*
  * *stellar_account_buying_liabilities*
  * *stellar_account_selling_liabilities*
  * *stellar_account_num_sponsored*
  * *stellar_account_num_sponsoring*
- * *stellar_account_available_balance*
 
 Each metric has the following labels:
  * *network* - network name from the configuration file

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For each account the following metrics are exported:
  * *stellar_account_selling_liabilities*
  * *stellar_account_num_sponsored*
  * *stellar_account_num_sponsoring*
- * *stellar_account_minimum_balance*
+ * *stellar_account_available_balance*
 
 Each metric has the following labels:
  * *network* - network name from the configuration file

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="stellar-account-prometheus-exporter",
-    version="0.0.3",
+    version="0.0.4",
     author="Stellar Development Foundation",
     author_email="ops@stellar.org",
     description="Export stellar account balance in prometheus format",

--- a/stellar_account_prometheus_exporter/exporter.py
+++ b/stellar_account_prometheus_exporter/exporter.py
@@ -70,7 +70,7 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
         m_selling_liabilities = Gauge("stellar_account_selling_liabilities", "Stellar core account selling liabilities",
                                       balance_label_names, registry=self.registry)
         m_available_balance = Gauge("stellar_account_available_balance", "Stellar core account available balance, i.e. the account balance exceding the minimum required balance of `(2 + subentry_count + num_sponsoring - num_sponsored) * 0.5 + liabilities.selling`",
-                                    balance_label_names[:3], registry=self.registry)
+                                    balance_label_names, registry=self.registry)
 
         for network in config["networks"]:
             if "accounts" not in network or "name" not in network or "horizon_url" not in network:

--- a/stellar_account_prometheus_exporter/exporter.py
+++ b/stellar_account_prometheus_exporter/exporter.py
@@ -114,7 +114,7 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
                     m_selling_liabilities.labels(*labels).set(balance["selling_liabilities"])
 
                     # ref: https://github.com/stellar/stellar-protocol/blob/a664806db12635ab4d49b3f006c8f1b578fba8d4/core/cap-0033.md#reserve-requirement
-                    minimum_required_balance = balance["selling_liabilities"]
+                    minimum_required_balance = float(balance["selling_liabilities"])
                     if balance["asset_type"] == "native":
                         minimum_required_balance += 0.5 * (2 + r.json()["subentry_count"] + r.json()["num_sponsoring"] - r.json()["num_sponsored"])
                     m_available_balance.labels(*labels).set(balance["balance"] - minimum_required_balance)

--- a/stellar_account_prometheus_exporter/exporter.py
+++ b/stellar_account_prometheus_exporter/exporter.py
@@ -55,19 +55,22 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         self.registry = CollectorRegistry()
-        label_names = ["network", "account_id", "account_name", "asset_type"]
-        m_balance = Gauge("stellar_account_balance", "Stellar core account balance",
-                          label_names, registry=self.registry)
-        m_buying_liabilities = Gauge("stellar_account_buying_liabilities", "Stellar core account buying liabilities",
-                                     label_names, registry=self.registry)
-        m_selling_liabilities = Gauge("stellar_account_selling_liabilities", "Stellar core account selling liabilities",
-                                      label_names, registry=self.registry)
+
+        account_label_names = ["network", "account_id", "account_name"]
         m_num_sponsored = Gauge("stellar_account_num_sponsored", "Stellar core account number of sponsored entries",
-                                label_names, registry=self.registry)
+                                account_label_names, registry=self.registry)
         m_num_sponsoring = Gauge("stellar_account_num_sponsoring", "Stellar core account number of sponsoring entries",
-                                 label_names, registry=self.registry)
+                                 account_label_names, registry=self.registry)
+
+        balance_label_names = account_label_names + ["asset_type"]
+        m_balance = Gauge("stellar_account_balance", "Stellar core account balance",
+                          balance_label_names, registry=self.registry)
+        m_buying_liabilities = Gauge("stellar_account_buying_liabilities", "Stellar core account buying liabilities",
+                                     balance_label_names, registry=self.registry)
+        m_selling_liabilities = Gauge("stellar_account_selling_liabilities", "Stellar core account selling liabilities",
+                                      balance_label_names, registry=self.registry)
         m_available_balance = Gauge("stellar_account_available_balance", "Stellar core account available balance, i.e. the account balance exceding the minimum required balance of `(2 + subentry_count + num_sponsoring - num_sponsored) * 0.5 + liabilities.selling`",
-                                    label_names, registry=self.registry)
+                                    balance_label_names[:3], registry=self.registry)
 
         for network in config["networks"]:
             if "accounts" not in network or "name" not in network or "horizon_url" not in network:

--- a/stellar_account_prometheus_exporter/exporter.py
+++ b/stellar_account_prometheus_exporter/exporter.py
@@ -111,7 +111,9 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
                     m_selling_liabilities.labels(*labels).set(balance["selling_liabilities"])
 
                     # ref: https://github.com/stellar/stellar-protocol/blob/a664806db12635ab4d49b3f006c8f1b578fba8d4/core/cap-0033.md#reserve-requirement
-                    minimum_required_balance = balance["selling_liabilities"] + 0.5 * (2 + r.json()["subentry_count"] + r.json()["num_sponsoring"] - r.json()["num_sponsored"])
+                    minimum_required_balance = balance["selling_liabilities"]
+                    if balance["asset_type"] == "native":
+                        minimum_required_balance += 0.5 * (2 + r.json()["subentry_count"] + r.json()["num_sponsoring"] - r.json()["num_sponsored"])
                     m_available_balance.labels(*labels).set(balance["balance"] - minimum_required_balance)
 
         output = generate_latest(self.registry)

--- a/stellar_account_prometheus_exporter/exporter.py
+++ b/stellar_account_prometheus_exporter/exporter.py
@@ -117,7 +117,7 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
                     minimum_required_balance = float(balance["selling_liabilities"])
                     if balance["asset_type"] == "native":
                         minimum_required_balance += 0.5 * (2 + r.json()["subentry_count"] + r.json()["num_sponsoring"] - r.json()["num_sponsored"])
-                    m_available_balance.labels(*labels).set(balance["balance"] - minimum_required_balance)
+                    m_available_balance.labels(*labels).set(float(balance["balance"]) - minimum_required_balance)
 
         output = generate_latest(self.registry)
         self.send_response(200)


### PR DESCRIPTION
### What
Export account's available balance through the gauge `stellar_account_available_balance`.

### Why
The raw balance itself may be a misleading metric since it doesn't account for the base reserves needed to hold trustlines, signers, selling liabilities nor sponsorships. 

If you want to know when it's time to top-up an account the new metric `stellar_account_available_balance` is more suitable.