### PR TITLE
Handle missing account properly in stellar account exporter

### DIFF
--- a/stellar_account_prometheus_exporter/exporter.py
+++ b/stellar_account_prometheus_exporter/exporter.py
@@ -2,6 +2,7 @@
 # vim: tabstop=4 expandtab shiftwidth=4
 
 import argparse
+import logging
 import requests
 import yaml
 import threading
@@ -22,7 +23,9 @@ except ImportError:
     unicode = str
     from http.server import BaseHTTPRequestHandler, HTTPServer
     from socketserver import ThreadingMixIn
-
+# Initialize logger
+logging.basicConfig(level=logging.ERROR)
+logger = logging.getLogger("stellar-account-exporter")
 
 parser = argparse.ArgumentParser(description='Exposes staller account balance to prometheus')
 parser.add_argument('--port', type=int,
@@ -75,6 +78,11 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
         m_available_balance = Gauge("stellar_account_available_balance", "Stellar core account available balance, i.e. the account balance exceding the minimum required balance of `(2 + subentry_count + num_sponsoring - num_sponsored) * 0.5 + liabilities.selling`",
                                     balance_label_names, registry=self.registry)
 
+        m_balance_exists = Gauge("stellar_account_balance_success", "Displays whether or not Stellar core account balance is present",
+                                account_label_names, registry=self.registry)
+        m_available_balance_exists = Gauge("stellar_account_available_balance_success", "Displays whether or not Stellar core account available balance is present",
+                                            account_label_names, registry=self.registry)
+
         for network in config["networks"]:
             if "accounts" not in network or "name" not in network or "horizon_url" not in network:
                 self.error(500, 'Error - invalid network configuration: {}'.format(network))
@@ -93,17 +101,23 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
                     return
                 if not r.ok:
                     m_account_exists.labels(*account_labels).set(0)
+                    logger.error("Error retrieving data from {}".format(url))
                     continue
                 if "balances" not in r.json():
-                    self.error(500, "Error - no balances found for account {}".format(account["account_id"]))
-                    return
+                    m_balance_exists.labels(*account_labels).set(0)
+                    logger.error("Error - no balances found for account {}".format(account["account_id"]))
+                    continue
                 if "subentry_count" not in r.json():
-                    self.error(500, "Error - no subentry_count found for account {}".format(account["account_id"]))
-                    return
+                    m_available_balance_exists.labels(*account_labels).set(0)
+                    logger.error("Error - no subentry_count found for account {}".format(account["account_id"]))
+                    continue
 
                 m_num_sponsored.labels(*account_labels).set(r.json().get("num_sponsored", 0))
                 m_num_sponsoring.labels(*account_labels).set(r.json().get("num_sponsoring", 0))
+
                 m_account_exists.labels(*account_labels).set(1)
+                m_balance_exists.labels(*account_labels).set(1)
+                m_available_balance_exists.labels(*account_labels).set(1)
 
                 for balance in r.json()["balances"]:
                     labels = [network["name"], account["account_id"], account["account_name"], balance["asset_type"]]

--- a/stellar_account_prometheus_exporter/exporter.py
+++ b/stellar_account_prometheus_exporter/exporter.py
@@ -65,7 +65,7 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
         m_num_sponsoring = Gauge("stellar_account_num_sponsoring", "Stellar core account number of sponsoring entries",
                                  account_label_names, registry=self.registry)
 
-        m_account_exists = Gauge("stellar_account_success", "Displays whether or not stellar core account is present",
+        m_account_exists = Gauge("stellar_account_scrape_success", "Indicates whether data was gathered successfully",
                                     account_label_names, registry=self.registry)
 
         balance_label_names = account_label_names + ["asset_type"]


### PR DESCRIPTION
### What

This will add a new metric `stellar_account_success`. Value of the `stellar_account_success` will be `1` if account exists and `0` if account doesn't exist.    


### Why
Currently, exporter returns no data if account doesn't exist and also if a particular account from the list of accounts provided via config doesn't exist then exporter breaks without reporting data regarding the accounts which exists.

Addresses: https://github.com/stellar/stellar-account-prometheus-exporter/issues/8

Signed-off-by: Satyam Zode <satyamz@users.noreply.github.com>