### PR TITLE
Bump Docker base to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gnupg2 wget apt-utils apt-transport-https ca-certificates
-RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add - && \
-    echo "deb https://apt.stellar.org/public stable/" | tee -a /etc/apt/sources.list.d/SDF.list
+    gnupg2 curl apt-utils apt-transport-https ca-certificates
+RUN curl -sSL https://apt.stellar.org/SDF.asc|gpg --dearmor >/etc/apt/trusted.gpg.d/SDF.gpg && \
+    echo "deb https://apt.stellar.org jammy stable" | tee -a /etc/apt/sources.list.d/SDF.list
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends stellar-account-prometheus-exporter
 
 EXPOSE 9618


### PR DESCRIPTION
* bump Docker base to 22.04
* switch to new repo definition format
* switch to new way of managing apt keys