### PR TITLE
Switch Ubuntu base image to 22.04 from 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 wget apt-utils apt-transport-https ca-certificates
 RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add - 
-RUN echo -n 'deb https://apt.stellar.org focal stable\n\n' | tee /etc/apt/sources.list.d/SDF.list
+RUN echo -n 'deb https://apt.stellar.org jammy stable\n\n' | tee /etc/apt/sources.list.d/SDF.list
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends stellar-account-prometheus-exporter
 
 EXPOSE 9618

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 wget apt-utils apt-transport-https ca-certificates
 RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add - 


### PR DESCRIPTION

### What

Switch Ubuntu base image to 22.04 from 20.04
### Why

We are moving other images to 22.04, this change improves consistency across SDF docker images.
