### PR TITLE
Revert Ubuntu 22.04 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 wget apt-utils apt-transport-https ca-certificates
 RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add - 
-RUN echo -n 'deb https://apt.stellar.org jammy stable\n\n' | tee /etc/apt/sources.list.d/SDF.list
+RUN echo -n 'deb https://apt.stellar.org focal stable\n\n' | tee /etc/apt/sources.list.d/SDF.list
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends stellar-account-prometheus-exporter
 
 EXPOSE 9618


### PR DESCRIPTION
### What:
Revert Ubuntu 22.04 upgrade


### Why:

Python3.10 error handling breaks the exporter. We need to fix the error handling and then land the Ubuntu upgrade. 