### PR TITLE
revert back to previous Dockerfile using 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 wget apt-utils apt-transport-https ca-certificates
 RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add - 
-RUN echo -n 'deb https://apt.stellar.org jammy stable\n\n' | tee /etc/apt/sources.list.d/SDF.list
+RUN echo -n 'deb https://apt.stellar.org focal stable\n\n' | tee /etc/apt/sources.list.d/SDF.list
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends stellar-account-prometheus-exporter
 
 EXPOSE 9618


### PR DESCRIPTION
### What
revert back to previous Dockerfile using 20.04

### Why
22.04 broke the exporter
see https://stellarfoundation.slack.com/archives/C066WEKT7PF/p1701207219218709

### Testing
has been tested

### Issue addressed by this PR
N/A