### PR TITLE
Fix error handling in exporter and move to py3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 wget apt-utils apt-transport-https ca-certificates
 RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add - 
-RUN echo -n 'deb https://apt.stellar.org focal stable\n\n' | tee /etc/apt/sources.list.d/SDF.list
+RUN echo -n 'deb https://apt.stellar.org jammy stable\n\n' | tee /etc/apt/sources.list.d/SDF.list
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends stellar-account-prometheus-exporter
 
 EXPOSE 9618

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="stellar-account-prometheus-exporter",
-    version="0.0.6",
+    version="0.0.7",
     author="Stellar Development Foundation",
     author_email="ops@stellar.org",
     description="Export stellar account balance in prometheus format",

--- a/stellar_account_prometheus_exporter/exporter.py
+++ b/stellar_account_prometheus_exporter/exporter.py
@@ -8,6 +8,7 @@ import yaml
 import threading
 import time
 from os import environ
+import errno
 
 # Prometheus client library
 from prometheus_client import CollectorRegistry
@@ -16,7 +17,7 @@ from prometheus_client.exposition import CONTENT_TYPE_LATEST, generate_latest
 
 
 try:
-    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+    from http.server import BaseHTTPRequestHandler, HTTPServer
     from SocketServer import ThreadingMixIn
 except ImportError:
     # Python 3
@@ -127,8 +128,9 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
         self.end_headers()
         try:
             self.wfile.write(output)
-        except BrokenPipeError as e:
-            print(e)
+        except IOError as e:
+            if e.errno == errno.EPIPE:
+                pass
 
 def main():
     httpd = _ThreadingSimpleServer(("", args.port), StellarCoreHandler)


### PR DESCRIPTION
### What:
- Fix error handling in exporter
- Move to py3 http.server module
- Upgrade ubuntu  base imageto 22.04 


### Why:
We need to ensure exporter doesn't exit with non zero exit code due to the timeouts to horizon api and when client reset the connection. 